### PR TITLE
Fixing Dockerfile for NVIDIA GPG keys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
 # Set-up docker image for DYGIE++.
 FROM pytorch/pytorch:1.6.0-cuda10.1-cudnn7-devel
 
+# Fix GPG keys for NVIDIA as per here https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/
+# then, install:
+# Required-base: set-up shared DYGIE++ modeling environment.
+# GCC and make needed to compile python deps. SQLite3 for Optuna hyperparameter optimization.
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos//ubuntu1804/x86_64/3bf863cc.pub && \
+     apt-get update && \
+    apt-get -y install wget gcc make sqlite3
+
 # Datasets will be downloaded to the /dygiepp root directory in image.
 # Please mount source code project dir at /dygiepp for using default paths.
 RUN mkdir /dygiepp
 
-# Required-base: set-up shared DYGIE++ modeling environment.
-# GCC and make needed to compile python deps. SQLite3 for Optuna hyperparameter optimization.
-RUN apt-get update && \
-    apt-get -y install gcc make sqlite3
 RUN conda create --name dygiepp python=3.7 -y
 SHELL ["conda", "run", "-n", "dygiepp", "/bin/bash", "-c"]
 # jsonnet has a conflict when installed with pip for now, install from conda.


### PR DESCRIPTION
NVIDIA GPG keys have been rotated since the base image build. Without this fixes, the container build fails. 
This PR fixes the build by using latest key as per https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/. 

Without this PR, the docker build sees following failure:

```
31.36 Reading package lists...
32.71 W: GPG error: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
32.71 E: The repository 'https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease' is not signed.
------
ERROR: failed to solve: executor failed running [/bin/sh -c apt-get update &&     apt-get -y install gcc make sqlite3]: exit code: 100
(
```